### PR TITLE
Add a restrictive license check

### DIFF
--- a/.github/workflows/licenseCheck.yaml
+++ b/.github/workflows/licenseCheck.yaml
@@ -1,0 +1,10 @@
+on: [pull_request]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: License compliance check
+        uses: mikaelvesavuori/license-compliance-action@v1.0.2
+        with:
+          allow_licenses: "MIT;Apache-2.0"


### PR DESCRIPTION
Add a restrictive license check (only allow MIT & Apache 2.0) to demonstrate how the [license-compliance ](https://github.com/marketplace/actions/license-compliance#allow_licenses)action works for a Bug Driven Development Blog Post